### PR TITLE
[ftx] Don't crash on expiring delivery future in `fetch_markets()`

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -586,7 +586,9 @@ module.exports = class ftx extends Exchange {
                 type = 'future';
                 expiry = this.parse8601 (expiryDatetime);
                 if (expiry === undefined) {
-                    throw new BadResponse (this.id + " symbol '" + id + "' is a future contract but with an invalid expiry datetime.");
+                    // It is likely a future that is expiring in this moment
+                    self.log (this.id + " symbol '" + id + "' is a future contract but with an invalid expiry datetime.");
+                    continue;
                 }
                 const parsedId = id.split ('-');
                 const length = parsedId.length;


### PR DESCRIPTION
At the end of the day (00:00 UTC), we are observing crashes in `fetch_markets()` because of delivery futures that are apparently with `undefined` expiry (#12104).

The problem seems to be caused by the fact that the results of two API call of FTX are not coherent, so that no expiry is reported for a delivery future that is expiring just now.

This PR logs the error and ignores the invalid symbol (which is expired anyways).

See also: #12017 #11544